### PR TITLE
Update Self-Hosted Parallel Job Resources

### DIFF
--- a/docs/pipelines/licensing/concurrent-jobs.md
+++ b/docs/pipelines/licensing/concurrent-jobs.md
@@ -41,12 +41,11 @@ If you want Azure Pipelines to orchestrate your builds and releases, but use you
 
 We provide a *free tier* of service by default in your organization:
 
-- Public project: 10 free self-hosted parallel jobs.
+- Public project: Unlimited parallel jobs.
 - Private project: One self-hosted parallel job. Additionally, for each active Visual Studio Enterprise subscriber who is a member of your organization, you get one additional self-hosted parallel job.
 
 When the free tier is no longer sufficient:
 
-- Public project: [Contact us](https://azure.microsoft.com/support/devops/) to get your free tier limits increased.
 - Private project: You can pay for additional capacity per parallel job. [Buy self-hosted parallel jobs](https://marketplace.visualstudio.com/items?itemName=ms.build-release-private-pipelines).
 
 There are no time limits on self-hosted jobs.


### PR DESCRIPTION
Public projects are no longer limited to 10 self-hosted parallel jobs. This updates the documentation to 
reflect that there are no longer limits on the number of self-hosted jobs they can run.

Fixes: #4802